### PR TITLE
Improve error handling when webcam access fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import cv2
+import sys
 import numpy as np
 import os
 import face_recognition
@@ -34,7 +35,14 @@ for person_name in os.listdir(data_path):
                     face_encode.append(face_encodings[0])  
                     face_name.append(person_name)  
 
-face_cap = cv2.VideoCapture(0)
+try:
+    face_cap = cv2.VideoCapture(0)
+    if not face_cap.isOpened():
+        raise RuntimeError("❌ Error: Could not access the webcam. Please check if it's connected or in use.")
+except Exception as e:
+    print(str(e))
+    sys.exit()
+
 detection_time = {}  
 last_alarmed = {}    
 


### PR DESCRIPTION
This pull request improves the robustness of the face recognition system by adding proper error handling for scenarios where the webcam is not accessible.

Changes Made:
Added a try-except block around cv2.VideoCapture(0) to catch cases when the webcam is not found or already in use.
Raised a RuntimeError with a clear and user-friendly message.
Used sys.exit() to terminate the program gracefully if the camera fails to initialize.
Preserved the finally block to ensure that resources are properly released even if an error occurs.
issue #8