### PR TITLE
Add snapshot saving for matched individuals

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,9 +6,13 @@ from playsound import playsound
 from message import send_email, send_sms
 import time
 import sys
-from gui.gui import guiwindow  
+from gui.gui import guiwindow
+import datetime
+
 
 prev_time = 0
+LOG_DIR = "logs"
+
 
 # Alarms
 def threat_alarm():
@@ -113,6 +117,10 @@ def get_frame():
                 threat_alarm()
                 send_email(name, frame, confidence)
                 send_sms(name,confidence)
+                timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                filename = f"{name}_{timestamp}.jpg"
+                filepath = os.path.join(LOG_DIR, filename)
+                cv2.imwrite(filepath, frame)
             else:
                 safe_alarm()
             last_alarmed[name] = curr_time


### PR DESCRIPTION
This PR adds the ability to capture and save snapshots only when a known individual is detected by the system.
Key Updates:
Snapshot Saving: When a confirmed face match occurs (after 10 seconds of detection), the system captures a full-frame snapshot.
Organized Logging: Snapshots are saved in a logs/ directory, which is created if missing.
Timestamped Files: Snapshot filenames follow the pattern <name>_<timestamp>.jpg
Privacy Focused: Snapshots are only saved for matched individuals. No images of unmatched or innocent people are stored.

issue #31 