### PR TITLE
Add regex validation for 16-character app passwords

### DIFF
--- a/message.py
+++ b/message.py
@@ -13,6 +13,8 @@ from twilio.rest import Client
 
 load_dotenv()
 
+
+
 def is_valid_email(email):
     pattern = r'^[\w\.-]+@[\w\.-]+\.\w+$'
     return re.match(pattern, email) is not None
@@ -21,7 +23,7 @@ def is_valid_password(password):
     if not password:
         return False
     clean = password.replace(" ", "")
-    return len(clean) == 16
+    return bool(re.fullmatch(r"[a-zA-Z0-9]{16}", clean))
 
 
 def location():
@@ -61,7 +63,7 @@ if not all(is_valid_email(email) for email in receiver_emails + [sender_email]):
     raise ValueError("One or more email addresses are invalid.")
 
 if not is_valid_password(sender_password):
-    raise ValueError("Invalid Gmail app password format. It should be 16 alphabetic characters (with or without spaces).")
+    raise ValueError("Invalid Gmail app password format")
 
 def send_sms(name, confidence): 
      #city, region, googlemaps_link


### PR DESCRIPTION
This update adds validation logic for app passwords to ensure they strictly follow the expected format:

Exactly 16 characters
Contains only uppercase letters, lowercase letters, and digits
No special characters like @, #, !, etc.
