### PR TITLE
Add phone number validation using phonenumbers library

### DIFF
--- a/message.py
+++ b/message.py
@@ -9,6 +9,8 @@ import re
 import requests
 from dotenv import load_dotenv
 from twilio.rest import Client
+import phonenumbers
+from phonenumbers import geocoder, carrier
 
 
 
@@ -24,6 +26,14 @@ def is_valid_password(password):
         return False
     clean = password.replace(" ", "")
     return bool(re.fullmatch(r"[a-zA-Z0-9]{16}", clean))
+
+def is_valid_number(number, region="IN"):
+    try:
+        parsed = phonenumbers.parse(number, region)
+        return phonenumbers.is_valid_number(parsed)
+    except phonenumbers.NumberParseException:
+        return False
+
 
 
 def location():
@@ -45,8 +55,17 @@ receiver_emails = os.getenv('RECEIVER_EMAIL', '').split(',')
 twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
 twilio_token = os.getenv("TWILIO_AUTH_TOKEN")
 twilio_phone = os.getenv("TWILIO_PHONE_NUMBER")
+
 alert_phones = os.getenv("ALERT_PHONE_NUMBERS", "").split(",")
 client = Client(twilio_sid, twilio_token)
+
+if not is_valid_number(twilio_phone):
+    raise ValueError(f"Invalid Twilio phone number: {twilio_phone}")
+
+for num in alert_phones:
+    num = num.strip()
+    if not is_valid_number(num):
+        raise ValueError(f"Invalid alert phone number: {num}")
 
 values = {
     "SENDER_EMAIL": sender_email,


### PR DESCRIPTION
This PR adds strict validation for phone numbers used in the Security Screening System, specifically:
Validates `TWILIO_PHONE_NUMBER` from `.env` using the `phonenumbers` library.
Parses and validates all numbers in `ALERT_PHONE_NUMBERS`, ensuring they are in proper format (e.g., +91xxxxxxxxxx`).
Raises a `ValueError` with a helpful message if any phone number is invalid.

issue #88 