### PR TITLE
reset the time counter when accessory detected

### DIFF
--- a/main.py
+++ b/main.py
@@ -247,6 +247,9 @@ class SecuritySystem:
         # -------------- Accessory Detection Before Face Recognition --------------
         accessories = self.detect_accessories(frame)
         if accessories:
+            # Reset the countdown timer when an accessory is detected
+            self.detection_time.clear()
+            
             self.current_status = f"⚠️ Please remove: {', '.join(accessories).title()}"
             speak_event("remove_accessory", f"Please remove: {', '.join(accessories)}")
             self.status_color = '#ff0000'


### PR DESCRIPTION
**Issue Closes** #123 

cleared the detection_time when an accessory detected on a person face, so that the face recognition countdown timer reset to 10s.

added 
```python
            # Reset the countdown timer when an accessory is detected
            self.detection_time.clear()
```
in the code block
```python
        accessories = self.detect_accessories(frame)
        if accessories:
            self.current_status = f"⚠️ Please remove: {', '.join(accessories).title()}"
            speak_event("remove_accessory", f"Please remove: {', '.join(accessories)}")
            self.status_color = '#ff0000'
            return frame  # Skip face recognition while showing live frames
```